### PR TITLE
README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,0 @@
-# doc-template
-document template
-
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
-  <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
-  <br />
-  This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
-  Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-  

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,19 @@
-Relational Registry/RegTAP Source Distribution
-==============================================
+Relational Registry, a.k.a., RegTAP
+===================================
 
-What's what?
+These are the sources for the IVOA standard used by clients to query the
+VO Registry.
 
-* RegTAP.tex -- the document source code.  This is what you
-  should be editing
+The document uses ivoatex_ to build; hence, a simple ``make`` should
+give you a pdf, provided you have the ivoatex dependencies installed.
+
+In addition to the usual ivoatex files, there is here, in particular:
+
 * makeutypes.xslt -- the XSLT to generate utypes from VOResource input; there's
   a wrapper around this in the Makefile (this is included in the standard)
-* Makefile -- document date, version, and status are defined in there.
 * check_examples.py -- runs the embedded examples and complains if
   the TAP server errors out or returns an empty response.  Not needed
   to build the document, see embeeded comments for details.
 * gettables.sh, maketable.sh -- helper scripts for generated material
-  in the document (make generate).  These assume a server with rr at
-  http://localhost:8080/tap
+  in the document (make generate).  These assume a TAP server with the rr 
+  schema at http://localhost:8080/tap


### PR DESCRIPTION
This doesn't have the CC-BY badge on the front page any more -- I'd say that's reasonable, in particular because it saves a cross-site request (to the CC logo).