### PR TITLE
Backing out of \rtent for table content.

### DIFF
--- a/RegTAP.tex
+++ b/RegTAP.tex
@@ -923,7 +923,7 @@ registry.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.resource} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.resource table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1111,7 +1111,7 @@ matching in RegTAP at this point should be very lenient.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.res\_role} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.res\_role table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1193,7 +1193,7 @@ string-like 1:n members of resource.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.res\_subject} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.res\_subject table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1251,7 +1251,7 @@ capabilities on a single resource.  See section \ref{primarykeys} for details.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.capability} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.capability table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1321,7 +1321,7 @@ multiple schema elements on a single resource.  See section \ref{primarykeys} fo
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.res\_schema} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.res\_schema table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1403,7 +1403,7 @@ must be per resource and \emph{not} per schema, as
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.res\_table} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.res\_table table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1507,7 +1507,7 @@ to vs; hence, this column will contain one of NULL,
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.table\_column} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.table\_column table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1703,7 +1703,7 @@ interface.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.interface} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.interface table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1814,7 +1814,7 @@ joined.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.intf\_param} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.intf\_param table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -1924,7 +1924,7 @@ between the two representations in the database ingestor.
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.relationship} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.relationship table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2008,7 +2008,7 @@ correct).
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.validation} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.validation table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2066,7 +2066,7 @@ The \rtent{res_date} table contains information gathered from
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.res\_date} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.res\_date table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2168,7 +2168,7 @@ IVOA-approved VOResource extensions MUST or SHOULD be present in
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.res\_detail} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.res\_detail table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2238,7 +2238,7 @@ identifiers:
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.alt\_identifier} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.alt\_identifier table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2276,7 +2276,7 @@ spatial coverage using spatial MOCs \citep{2019ivoa.spec.1007F}.  The
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.stc\_spatial} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.stc\_spatial table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2330,7 +2330,7 @@ temporal coverage as a union of time intervals.  The
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.stc\_temporal} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.stc\_temporal table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2381,7 +2381,7 @@ spectral coverage as a union of energy intervals.  The
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.stc\_spectral} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.stc\_spectral table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax ivoid\hfil\break
@@ -2459,7 +2459,7 @@ The \rtent{tap_table} view has the following columns:
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.tap\_table} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.tap\_table table}}\\
 \sptablerule
 
 \baselineskip=9pt\relax resid\hfil\break

--- a/columnstotex.xslt
+++ b/columnstotex.xslt
@@ -14,7 +14,7 @@
 \small
 \begin{tabular}{p{0.28\textwidth}p{0.2\textwidth}p{0.66\textwidth}}
 \sptablerule
-\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the \rtent{rr.<value-of select="@name"/>} table}}\\
+\multicolumn{3}{l}{\textit{Column names, utypes, datatypes, and descriptions for the rr.<value-of select="@name"/> table}}\\
 \sptablerule
 <apply-templates/>
 \sptablerule


### PR DESCRIPTION
The problem is that the catcode magic I'm doing in rtent doesn't
go well with multicolumn, and it's painful to cover this all when there's
HTML output to be thought about, too.  Ah well.