### PR TITLE
do not create the schema.pdf unless sources change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ all: $(DOCNAME).pdf
 schema.pdf: schema.psfig
 	ps2pdf -dALLOWPSTRANSPARENCY -dEPSCrop $< $@
 
+# do not do this build unless absolutely necessary - pdf checked in
+.SECONDARY: schema.psfig
 %.psfig: %.texfig
 	etex $<
 	dvips $*


### PR DESCRIPTION
schema.pdf is checked-in and therefore does not need to be built unless its actual
 source changes - getting pstricks to run nowadays seems tricky